### PR TITLE
feat: Setup DataHighway sample endpoints with sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ yarn-error.log
 /.clinic
 **.log
 **/logs
+
+/calc/pkg/calc.js
+/calc/pkg/calc_bg.wasm
+/docs/dist/app.bundle.js

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ yarn
 
 Run a local DataHighway node in separate tab
 
+Ensure that in src/chains-config.index.ts the spec_name from the DataHighway repository's node runtime matches the name included in this file (e.g. `'datahighway': harbourTestnetControllers,`, where `'datahighway'` is the spec_name), otherwise it'll use the defaultController instead
+
 Swagger Docs
 ```
 cd docs/

--- a/README.md
+++ b/README.md
@@ -113,7 +113,11 @@ cd docs/
 yarn
 yarn build
 ```
-Go to https://paritytech.github.io/substrate-api-sidecar/dist/
+
+Open in browser this file (similar to https://paritytech.github.io/substrate-api-sidecar/dist/)
+```
+open -a "Google Chrome" ./docs/dist/index.html
+```
 
 Change the endpoint if necessary (e.g. `SAS_SUBSTRATE_WS_URL=ws://127.0.0.1:99441` in .env.local)
 ```
@@ -127,13 +131,13 @@ brew install jq
 ```
 or `yarn dev`
 
-Queries such as https://paritytech.github.io/substrate-api-sidecar/dist/
+Create queries using the endpoints that are added to the Swagger docs (mentioned above):
 
 ```
 curl -s http://0.0.0.0:8080/blocks/head | jq
 curl -s http://0.0.0.0:8080/accounts/22242423424242424242423424242342342424432424242423/staking-info?at=111 | jq
-curl -s http://0.0.0.0:8080/pallets/mining-speed-boost/rates/token-mining/count | jq
-curl -s http://0.0.0.0:8080/pallets/mining-speed-boost/rates/token-mining/1 | jq
+curl -s http://0.0.0.0:8080/pallets/mining/mining-speed-boost/rates/token-mining/count | jq
+curl -s http://0.0.0.0:8080/pallets/mining/mining-speed-boost/rates/token-mining/1 | jq
 ```
 
 ### Running

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Queries such as https://paritytech.github.io/substrate-api-sidecar/dist/
 ```
 curl -s http://0.0.0.0:8080/blocks/head | jq
 curl -s http://0.0.0.0:8080/accounts/22242423424242424242423424242342342424432424242423/staking-info?at=111 | jq
-curl -s http://0.0.0.0:8080/roaming/profiles/network-servers/service-profiles | jq
 curl -s http://0.0.0.0:8080/pallets/mining-speed-boost/rates/token-mining/count | jq
 curl -s http://0.0.0.0:8080/pallets/mining-speed-boost/rates/token-mining/1 | jq
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,40 @@ Use yarn to do the remaining setup:
 yarn
 ```
 
+### Quickstart
+
+Run a local DataHighway node in separate tab
+
+Swagger Docs
+```
+cd docs/
+yarn
+yarn build
+```
+Go to https://paritytech.github.io/substrate-api-sidecar/dist/
+
+Change the endpoint if necessary (e.g. `SAS_SUBSTRATE_WS_URL=ws://127.0.0.1:99441` in .env.local)
+```
+export SAS_SUBSTRATE_TYPES=/Users/ls2/code/DataHighway-DHX/node/custom_types.json
+export SAS_LOG_LEVEL=silly
+export SAS_LOG_STRIP_ANSI=true
+CALC_DEBUG=1 sh calc/build.sh
+yarn build
+yarn start:log-rpc
+brew install jq
+```
+or `yarn dev`
+
+Queries such as https://paritytech.github.io/substrate-api-sidecar/dist/
+
+```
+curl -s http://0.0.0.0:8080/blocks/head | jq
+curl -s http://0.0.0.0:8080/accounts/22242423424242424242423424242342342424432424242423/staking-info?at=111 | jq
+curl -s http://0.0.0.0:8080/roaming/profiles/network-servers/service-profiles | jq
+curl -s http://0.0.0.0:8080/pallets/mining-speed-boost/rates/token-mining/count | jq
+curl -s http://0.0.0.0:8080/pallets/mining-speed-boost/rates/token-mining/1 | jq
+```
+
 ### Running
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
 # Sidecar OpenApi UI
 
 Proposed OpenApi spec for [substrate-api-sidecar](https://github.com/paritytech/substrate-api-sidecar) v1.
+
+```
+yarn
+yarn build
+```
+
+Open in browser this file
+```
+open -a "Google Chrome" ./docs/dist/index.html
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Substrate API Sidecar OpenApi</title>
+  <title>DataHighway's Substrate API Sidecar OpenApi</title>
   <link rel="icon" href="favicon.ico">
 </head>
 

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  title: Substrate API Sidecar v1.
-  description: Substrate API Sidecar is a REST service that makes it easy to
-    interact with blockchain nodes built using Substrate's FRAME framework.
+  title: DataHighway's Substrate API Sidecar v1.
+  description: DataHighway's Substrate API Sidecar is a REST service that makes it easy to
+    interact with DataHighway blockchain nodes built using Substrate's FRAME framework.
   contact:
     url: https://github.com/paritytech/substrate-api-sidecar
   license:
@@ -624,6 +624,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuntimeSpec'
+  /pallets/mining-speed-boost/rates/token-mining/{tokenMiningRateId}:
+    get:
+      tags:
+      - pallets
+      summary: Get a list of token mining rate objects stored for a specified tokenMiningRateId.
+      description: Returns a list of token mining rate objects stored for a specified tokenMiningRateId.
+      parameters:
+      - name: tokenMiningRateId
+        in: path
+        description: 'Index query the storage with'
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                description: Array of tokenMiningRates.
+                items:
+                  $ref: '#/components/schemas/PalletStorage'
+        "404":
+          description: could not find a list of token mining rate objects with the specified tokenMiningRateId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pallets/mining-speed-boost/rates/token-mining/count:
+    get:
+      tags:
+      - pallets
+      summary: Get the count of token mining rate objects in storage.
+      description: Returns the count of token mining rate objects in storage for use to determine the next tokenMiningRateId.
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Count of tokenMiningRates.
+                items:
+                  $ref: '#/components/schemas/PalletMiningSpeedBoostRatesTokenMiningsCount'
   /pallets/{palletId}/storage:
     get:
       tags:
@@ -1572,6 +1617,28 @@ components:
           type: string
         stack:
           type: string
+    PalletMiningSpeedBoostRatesTokenMinings:
+      type: array
+      properties:
+        miningSpeedBoostRatesTokenMinings:
+          type: object
+          items:
+            type: object
+            properties:
+              index:
+                type: string
+                format: hex
+                description: H256 hash of type opaque_blake2_256.
+              storageStruct:
+                type: object
+                format: hex
+                description: Storage struct of type [u8; 16].
+    PalletMiningSpeedBoostRatesTokenMiningsCount:
+      type: object
+      properties:
+        miningSpeedBoostRatesTokenMiningCount:
+          type: string
+          format: unsignedInteger
     PalletStorageType:
       type: object
       description: Info about the data structure used for storage.

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -628,8 +628,8 @@ paths:
     get:
       tags:
       - pallets
-      summary: Get a list of token mining rate objects stored for a specified tokenMiningRateId.
-      description: Returns a list of token mining rate objects stored for a specified tokenMiningRateId.
+      summary: Get the token mining rate hash that is stored to correspond to a specified token mining rate index.
+      description: Returns a token mining rate hash that is stored to correspond to a specified token mining rate index.
       parameters:
       - name: tokenMiningRateId
         in: path
@@ -643,12 +643,12 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                description: Array of tokenMiningRates.
+                type: string
+                description: token mining rate hash that is stored to correspond to a specific token mining rates index.
                 items:
                   $ref: '#/components/schemas/PalletStorage'
         "404":
-          description: could not find a list of token mining rate objects with the specified tokenMiningRateId
+          description: could not find a token mining rate hash value stored to correspond to the specified token mining rate index.
           content:
             application/json:
               schema:
@@ -657,8 +657,8 @@ paths:
     get:
       tags:
       - pallets
-      summary: Get the count of token mining rate objects in storage.
-      description: Returns the count of token mining rate objects in storage for use to determine the next tokenMiningRateId.
+      summary: Get the count of token mining rate indexes using storage.
+      description: Returns the count of token mining rate indexes using storage for use to determine the next token mining rate index.
       responses:
         "200":
           description: successful operation
@@ -666,7 +666,7 @@ paths:
             application/json:
               schema:
                 type: string
-                description: Count of tokenMiningRates.
+                description: Count of token mining rates indexes that have values in storage.
                 items:
                   $ref: '#/components/schemas/PalletMiningSpeedBoostRatesTokenMiningsCount'
   /pallets/{palletId}/storage:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -624,7 +624,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuntimeSpec'
-  /pallets/mining-speed-boost/rates/token-mining/{tokenMiningRateId}:
+  /pallets/mining/mining-speed-boost/rates/token-mining/{tokenMiningRateId}:
     get:
       tags:
       - pallets
@@ -653,7 +653,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /pallets/mining-speed-boost/rates/token-mining/count:
+  /pallets/mining/mining-speed-boost/rates/token-mining/count:
     get:
       tags:
       - pallets

--- a/src/chains-config/defaultControllers.ts
+++ b/src/chains-config/defaultControllers.ts
@@ -22,6 +22,7 @@ export const defaultControllers: ControllerConfig = {
 		TransactionMaterial: true,
 		TransactionFeeEstimate: true,
 		TransactionSubmit: true,
+		PalletsMiningSpeedBoostRatesTokenMining: false,
 		PalletsStakingProgress: true,
 		PalletsStorage: true,
 	},

--- a/src/chains-config/defaultControllers.ts
+++ b/src/chains-config/defaultControllers.ts
@@ -22,7 +22,7 @@ export const defaultControllers: ControllerConfig = {
 		TransactionMaterial: true,
 		TransactionFeeEstimate: true,
 		TransactionSubmit: true,
-		PalletsMiningSpeedBoostRatesTokenMining: false,
+		PalletsMiningSpeedBoostRatesTokenMining: true,
 		PalletsStakingProgress: true,
 		PalletsStorage: true,
 	},

--- a/src/chains-config/dockTestnetControllers.ts
+++ b/src/chains-config/dockTestnetControllers.ts
@@ -21,6 +21,7 @@ export const dockTestnetControllers: ControllerConfig = {
 		TransactionMaterial: true,
 		TransactionFeeEstimate: true,
 		TransactionSubmit: true,
+		PalletsMiningSpeedBoostRatesTokenMining: false,
 		PalletsStakingProgress: false,
 		PalletsStorage: true,
 	},

--- a/src/chains-config/harbourTestnetControllers.ts
+++ b/src/chains-config/harbourTestnetControllers.ts
@@ -1,28 +1,28 @@
 import { ControllerConfig } from '../types/chains-config';
 
 /**
- * Controllers for Dock's mainnet.
+ * Controllers for harbour, DataHighway's test network.
  */
-export const dockMainnetControllers: ControllerConfig = {
+export const harbourTestnetControllers: ControllerConfig = {
 	controllers: {
 		Blocks: true,
 		BlocksExtrinsics: true,
-		AccountsStakingPayouts: false,
+		AccountsStakingPayouts: true,
 		AccountsBalanceInfo: true,
-		AccountsStakingInfo: false,
-		AccountsVestingInfo: false,
+		AccountsStakingInfo: true,
+		AccountsVestingInfo: true,
 		NodeNetwork: true,
 		NodeVersion: true,
-		NodeTransactionPool: true,
+    NodeTransactionPool: true,
 		RuntimeCode: true,
 		RuntimeSpec: true,
 		RuntimeMetadata: true,
 		TransactionDryRun: true,
 		TransactionMaterial: true,
 		TransactionFeeEstimate: true,
-		TransactionSubmit: true,
-		PalletsMiningSpeedBoostRatesTokenMining: false,
-		PalletsStakingProgress: false,
+    TransactionSubmit: true,
+    PalletsMiningSpeedBoostRatesTokenMining: true,
+		PalletsStakingProgress: true,
 		PalletsStorage: true,
 	},
 	options: {

--- a/src/chains-config/index.ts
+++ b/src/chains-config/index.ts
@@ -14,7 +14,7 @@ import { mandalaControllers } from './mandalaControllers';
 const specToControllerMap = {
 	kulupu: kulupuControllers,
 	mandala: mandalaControllers,
-	'harbour-testnet': harbourTestnetControllers,
+	'datahighway': harbourTestnetControllers, // obtain this from `spec_name` in DataHighway repository's node runtime 
 	'dock-testnet': dockTestnetControllers,
 	'dock-main-runtime': dockMainnetControllers,
 };

--- a/src/chains-config/index.ts
+++ b/src/chains-config/index.ts
@@ -7,12 +7,14 @@ import { ControllerConfig } from '../types/chains-config';
 import { defaultControllers } from './defaultControllers';
 import { dockMainnetControllers } from './dockMainnetControllers';
 import { dockTestnetControllers } from './dockTestnetControllers';
+import { harbourTestnetControllers } from './harbourTestnetControllers';
 import { kulupuControllers } from './kulupuControllers';
 import { mandalaControllers } from './mandalaControllers';
 
 const specToControllerMap = {
 	kulupu: kulupuControllers,
 	mandala: mandalaControllers,
+	'harbour-testnet': harbourTestnetControllers,
 	'dock-testnet': dockTestnetControllers,
 	'dock-main-runtime': dockMainnetControllers,
 };

--- a/src/chains-config/kulupuControllers.ts
+++ b/src/chains-config/kulupuControllers.ts
@@ -18,6 +18,7 @@ export const kulupuControllers: ControllerConfig = {
 		TransactionMaterial: true,
 		TransactionFeeEstimate: true,
 		TransactionSubmit: true,
+		PalletsMiningSpeedBoostRatesTokenMining: false,
 		PalletsStakingProgress: false,
 		PalletsStorage: true,
 	},

--- a/src/chains-config/mandalaControllers.ts
+++ b/src/chains-config/mandalaControllers.ts
@@ -21,6 +21,7 @@ export const mandalaControllers: ControllerConfig = {
 		TransactionMaterial: true,
 		TransactionFeeEstimate: true,
 		TransactionSubmit: true,
+		PalletsMiningSpeedBoostRatesTokenMining: false,
 		PalletsStakingProgress: true,
 		PalletsStorage: true,
 	},

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -6,7 +6,7 @@ import {
 } from './accounts';
 import { Blocks, BlocksExtrinsics } from './blocks';
 import { NodeNetwork, NodeTransactionPool, NodeVersion } from './node';
-import { PalletsStakingProgress, PalletsStorage } from './pallets';
+import { PalletsMiningSpeedBoostRatesTokenMining, PalletsStakingProgress, PalletsStorage } from './pallets';
 import { RuntimeCode, RuntimeMetadata, RuntimeSpec } from './runtime';
 import {
 	TransactionDryRun,
@@ -25,6 +25,7 @@ export const controllers = {
 	AccountsStakingInfo,
 	AccountsVestingInfo,
 	AccountsStakingPayouts,
+	PalletsMiningSpeedBoostRatesTokenMining,
 	PalletsStakingProgress,
 	PalletsStorage,
 	NodeNetwork,

--- a/src/controllers/pallets/PalletsMiningSpeedBoostRatesTokenMiningController.ts
+++ b/src/controllers/pallets/PalletsMiningSpeedBoostRatesTokenMiningController.ts
@@ -1,0 +1,53 @@
+import { ApiPromise } from '@polkadot/api';
+import { RequestHandler } from 'express';
+
+import { PalletsMiningSpeedBoostRatesTokenMiningService } from '../../services';
+import { INumberParam } from '../../types/requests';
+import AbstractController from '../AbstractController';
+
+export default class PalletsMiningSpeedBoostRatesTokenMiningsController extends AbstractController<PalletsMiningSpeedBoostRatesTokenMiningService> {
+	constructor(api: ApiPromise) {
+    super(api, '/pallets/mining-speed-boost/rates/token-mining',
+    new PalletsMiningSpeedBoostRatesTokenMiningService(api));
+		this.initRoutes();
+	}
+
+	protected initRoutes(): void {
+		this.safeMountAsyncGetHandlers([
+      ['/:index', this.getPalletsMiningSpeedBoostRatesTokenMiningById],
+			['/count', this.getPalletsMiningSpeedBoostRatesTokenMiningCount],
+		]);
+	}
+  
+	/**
+	 * Get a MiningSpeedBoostRatesTokenMining by its index.
+	 *
+	 * @param req Express Request
+	 * @param res Express Response
+	 */
+	private getPalletsMiningSpeedBoostRatesTokenMiningById: RequestHandler<INumberParam> = async (
+    { params: { index } },
+		res
+	): Promise<void> => {
+		PalletsMiningSpeedBoostRatesTokenMiningsController.sanitizedSend(
+			res,
+			await this.service.fetchPalletsMiningSpeedBoostRatesTokenMiningById(index)
+		);
+  };
+
+  /**
+	 * Get MiningSpeedBoostRatesTokenMining count.
+	 *
+	 * @param req Express Request
+	 * @param res Express Response
+	 */
+	private getPalletsMiningSpeedBoostRatesTokenMiningCount: RequestHandler = async (
+    { query: { } },
+		res
+	): Promise<void> => {
+		PalletsMiningSpeedBoostRatesTokenMiningsController.sanitizedSend(
+			res,
+			await this.service.fetchPalletsMiningSpeedBoostRatesTokenMiningCount()
+		);
+	};
+}

--- a/src/controllers/pallets/PalletsMiningSpeedBoostRatesTokenMiningController.ts
+++ b/src/controllers/pallets/PalletsMiningSpeedBoostRatesTokenMiningController.ts
@@ -7,7 +7,7 @@ import AbstractController from '../AbstractController';
 
 export default class PalletsMiningSpeedBoostRatesTokenMiningsController extends AbstractController<PalletsMiningSpeedBoostRatesTokenMiningService> {
 	constructor(api: ApiPromise) {
-    super(api, '/pallets/mining-speed-boost/rates/token-mining',
+    super(api, '/pallets/mining/mining-speed-boost/rates/token-mining',
     new PalletsMiningSpeedBoostRatesTokenMiningService(api));
 		this.initRoutes();
 	}

--- a/src/controllers/pallets/index.ts
+++ b/src/controllers/pallets/index.ts
@@ -1,2 +1,3 @@
+export { default as PalletsMiningSpeedBoostRatesTokenMining } from './PalletsMiningSpeedBoostRatesTokenMiningController';
 export { default as PalletsStakingProgress } from './PalletsStakingProgressController';
 export { default as PalletsStorage } from './PalletsStorageController';

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,7 @@ async function main() {
 		api.rpc.system.chain(),
 		api.rpc.state.getRuntimeVersion(),
 	]);
+	console.log('specName: ', specName)
 
 	startUpPrompt(
 		config.SUBSTRATE.WS_URL,

--- a/src/services/pallets/PalletsMiningSpeedBoostRatesTokenMiningService.ts
+++ b/src/services/pallets/PalletsMiningSpeedBoostRatesTokenMiningService.ts
@@ -1,0 +1,36 @@
+import {
+  IPalletMiningSpeedBoostRatesTokenMining,
+  IPalletMiningSpeedBoostRatesTokenMiningCount
+} from 'src/types/responses';
+
+import { AbstractService } from '../AbstractService';
+
+export class PalletsMiningSpeedBoostRatesTokenMiningService extends AbstractService {
+	async fetchPalletsMiningSpeedBoostRatesTokenMiningById(index: string): Promise<IPalletMiningSpeedBoostRatesTokenMining> {
+    console.log('this.api.query', this.api.query, index)
+		let object;
+		// try {
+		// 	object = await this.api.query.palletsMiningSpeedBoostRatesTokenMiningById(index);
+		// } catch {
+		// 	object = 'Cannot query palletsMiningSpeedBoostRatesTokenMiningById from node.';
+		// }
+
+		return {
+			object
+		};
+  }
+
+	async fetchPalletsMiningSpeedBoostRatesTokenMiningCount(): Promise<IPalletMiningSpeedBoostRatesTokenMiningCount> {
+    console.log('this.api.query', this.api.query)
+		let count;
+		// try {
+		// 	count = await this.api.query.palletsMiningSpeedBoostRatesTokenMiningCount();
+		// } catch {
+		// 	count = 'Cannot query palletsMiningSpeedBoostRatesTokenMiningCount from node.';
+		// }
+
+		return {
+			count
+		};
+	}
+}

--- a/src/services/pallets/PalletsMiningSpeedBoostRatesTokenMiningService.ts
+++ b/src/services/pallets/PalletsMiningSpeedBoostRatesTokenMiningService.ts
@@ -7,27 +7,29 @@ import { AbstractService } from '../AbstractService';
 
 export class PalletsMiningSpeedBoostRatesTokenMiningService extends AbstractService {
 	async fetchPalletsMiningSpeedBoostRatesTokenMiningById(index: string): Promise<IPalletMiningSpeedBoostRatesTokenMining> {
-    console.log('this.api.query', this.api.query, index)
-		let object;
-		// try {
-		// 	object = await this.api.query.palletsMiningSpeedBoostRatesTokenMiningById(index);
-		// } catch {
-		// 	object = 'Cannot query palletsMiningSpeedBoostRatesTokenMiningById from node.';
-		// }
+		let hash;
+		try {
+			hash = await this.api.query
+				.dataHighwayMiningSpeedBoostRatesTokenMining
+				.miningSpeedBoostRatesTokenMinings(index);
+		} catch {
+			hash = 'Cannot query miningSpeedBoostRatesTokenMinings from node.';
+		}
 
 		return {
-			object
+			hash
 		};
   }
 
 	async fetchPalletsMiningSpeedBoostRatesTokenMiningCount(): Promise<IPalletMiningSpeedBoostRatesTokenMiningCount> {
-    console.log('this.api.query', this.api.query)
 		let count;
-		// try {
-		// 	count = await this.api.query.palletsMiningSpeedBoostRatesTokenMiningCount();
-		// } catch {
-		// 	count = 'Cannot query palletsMiningSpeedBoostRatesTokenMiningCount from node.';
-		// }
+		try {
+			count = await this.api.query
+				.dataHighwayMiningSpeedBoostRatesTokenMining
+				.miningSpeedBoostRatesTokenMiningCount();
+		} catch {
+			count = 'Cannot query miningSpeedBoostRatesTokenMiningCount from node.';
+		}
 
 		return {
 			count

--- a/src/services/pallets/index.ts
+++ b/src/services/pallets/index.ts
@@ -1,2 +1,3 @@
+export * from './PalletsMiningSpeedBoostRatesTokenMiningService';
 export * from './PalletsStakingProgressService';
 export * from './PalletsStorageService';

--- a/src/types/responses/PalletMiningSpeedBoostRatesTokenMining.ts
+++ b/src/types/responses/PalletMiningSpeedBoostRatesTokenMining.ts
@@ -1,0 +1,9 @@
+import { AnyJson } from '@polkadot/types/types';
+
+export interface IPalletMiningSpeedBoostRatesTokenMining {
+	object?: AnyJson | null;
+}
+
+export interface IPalletMiningSpeedBoostRatesTokenMiningCount {
+	count?: string | null;
+}

--- a/src/types/responses/PalletMiningSpeedBoostRatesTokenMining.ts
+++ b/src/types/responses/PalletMiningSpeedBoostRatesTokenMining.ts
@@ -1,9 +1,9 @@
-import { AnyJson } from '@polkadot/types/types';
+import { Codec } from '@polkadot/types/types';
 
 export interface IPalletMiningSpeedBoostRatesTokenMining {
-	object?: AnyJson | null;
+	hash?: string | Codec | null;
 }
 
 export interface IPalletMiningSpeedBoostRatesTokenMiningCount {
-	count?: string | null;
+	count?: string | Codec | null;
 }

--- a/src/types/responses/index.ts
+++ b/src/types/responses/index.ts
@@ -12,6 +12,7 @@ export * from './NodeNetwork';
 export * from './NodeTransactionPool';
 export * from './NodeVersion';
 export * from './Pallet';
+export * from './PalletMiningSpeedBoostRatesTokenMining';
 export * from './PalletStakingProgress';
 export * from './PalletStorage';
 export * from './PalletStorageItem';


### PR DESCRIPTION
Unable to get response from DataHighway node when I run the following:

```
curl -s http://0.0.0.0:8080/pallets/mining-speed-boost/rates/token-mining/count | jq

parse error: Invalid numeric literal at line 1, column 10
```

But the issue was resolved here https://github.com/paritytech/substrate-api-sidecar/issues/422